### PR TITLE
docs: add ReplayGain 2.0 plugin configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,16 +874,12 @@ ReplayGain tags to your music files.
 1. Go to **Options** > **Options...** > **Plugins** > **ReplayGain 2.0**.
 2. Set the **rsgain command** to:
 
-```text
-/usr/bin/rsgain
-```
-
-<!-- markdownlint-disable MD029 -->
+    ```text
+    /usr/bin/rsgain
+    ```
 
 3. Adjust any other settings (e.g., target loudness) as desired.
 4. Click **Make It So!** to save.
-
-<!-- markdownlint-enable MD029 -->
 
 > [!NOTE]
 > Since `rsgain` is bundled with the container, no additional installation is

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ database.
    * [GPU Acceleration Support](#gpu-acceleration-support)
    * [Access to Optical Drives](#access-to-optical-drives)
    * [Picard Command-Line Interface](#picard-command-line-interface)
+   * [ReplayGain 2.0](#replaygain-20)
    * [Support or Contact](#support-or-contact)
 
 ## Quick Start
@@ -852,6 +853,50 @@ release:
 ```
 docker exec <container name> picard-cli -e load mbid://release/dbd0ce67-cae6-33eb-8f5a-1143a30c2353
 ```
+
+## ReplayGain 2.0
+
+This container includes [rsgain](https://github.com/complexlogic/rsgain), a
+ReplayGain 2.0 scanner, already installed at `/usr/bin/rsgain`. You can use it
+with the ReplayGain 2.0 plugin for Picard to automatically calculate and write
+ReplayGain tags to your music files.
+
+### Installing the Plugin
+
+1. Open MusicBrainz Picard.
+2. Go to **Options** > **Plugins**.
+3. Click the **Available Plugins** tab.
+4. Find **ReplayGain 2.0** in the list and click **Install**.
+5. Restart Picard when prompted.
+
+### Configuring the Plugin
+
+1. Go to **Options** > **Options...** > **Plugins** > **ReplayGain 2.0**.
+2. Set the **rsgain command** to:
+
+```text
+/usr/bin/rsgain
+```
+
+<!-- markdownlint-disable MD029 -->
+
+3. Adjust any other settings (e.g., target loudness) as desired.
+4. Click **Make It So!** to save.
+
+<!-- markdownlint-enable MD029 -->
+
+> [!NOTE]
+> Since `rsgain` is bundled with the container, no additional installation is
+> required. The binary is ready to use at `/usr/bin/rsgain`.
+
+<!-- markdownlint-disable MD028 -->
+
+> [!IMPORTANT]
+> The ReplayGain 2.0 plugin processes files after they are saved by Picard.
+> Ensure your music files are accessible to the container via the configured
+> data volumes.
+
+<!-- markdownlint-enable MD028 -->
 
 ## Support or Contact
 


### PR DESCRIPTION
The ReplayGain 2.0 Picard plugin uses rsgain as its backend. This container already includes rsgain at `/usr/bin/rsgain`, but there are no instructions documenting this or how to configure the plugin to use it. This PR adds a dedicated section covering plugin installation and rsgain path configuration.